### PR TITLE
Support other delimiters

### DIFF
--- a/dplyr
+++ b/dplyr
@@ -56,7 +56,7 @@ read_data <- function(input) {
     ext <- tolower(tools::file_ext(input))
     switch(
         ext,
-        csv = readr::read_csv(input, col_types = readr::cols()),
+        csv = readr::read_delim(input, col_types = readr::cols()),
         rds = readRDS(input),
         stop("Unknown file extension: ", ext)
     )
@@ -93,7 +93,7 @@ if (length(input) == 1) {
     .data <- read_data(input)
 } else {
     if (opt$verbose) message("[input] reading CSV from stdin")
-    .data <- readr::read_csv(I(input), col_types = readr::cols())
+    .data <- readr::read_delim(I(input), col_types = readr::cols())
 }
 
 

--- a/dplyr
+++ b/dplyr
@@ -23,7 +23,7 @@ suppressMessages({
     library(dplyr)
 })
 
-
+stopifnot(utils::packageVersion("readr") >= "2.0.0")
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # configuration for docopt


### PR DESCRIPTION
Thanks for the nice tool.

Since version 2.0.0, `readr::read_delim` can [guess the delimiter](https://www.tidyverse.org/blog/2021/07/readr-2-0-0/#delimiter-guessing) without having to specify a `delim` argument. Replacing `read_csv` with `read_delim` can thus extend the CLI tool's support for other file formats, e.g., tsv (#14).